### PR TITLE
fix: subscribe exit handler only once

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,29 +1,35 @@
-export function getDestroyPromise()
+export const getDestroyPromise = (() =>
 {
-	return new Promise<void>((resolve, reject) =>
+	const promiseList: { resolve: (value?: void | PromiseLike<void> | undefined) => void, reject: (reason?: any) => void }[] = [];
+	function exitHandler(options: { cleanup?: boolean; exit?: boolean }, error: any)
 	{
-		function exitHandler(options: { cleanup?: boolean; exit?: boolean }, error: any)
+		if (options.cleanup)
 		{
-			if (options.cleanup)
-			{
-				resolve();
-			}
-			if (error)
-			{
-				console.error('error:', error);
-				reject(error);
-			}
-			if (options.exit)
-			{
-				process.exit();
-			}
+			promiseList.forEach(promise => promise.resolve());
 		}
+		if (error)
+		{
+			console.error('error:', error);
+			promiseList.forEach(promise => promise.reject(error));
+		}
+		if (options.exit)
+		{
+			process.exit();
+		}
+	}
 
-		// do something when app is closing
-		process.on('exit', exitHandler.bind(null, { cleanup: true }));
-		// catch ctrl+c event
-		process.on('SIGINT', exitHandler.bind(null, { exit: true }));
-		// catch uncaught exceptions
-		process.on('uncaughtException', exitHandler.bind(null, { exit: true }));
-	});
-}
+	// do something when app is closing
+	process.on('exit', exitHandler.bind(null, { cleanup: true }));
+	// catch ctrl+c event
+	process.on('SIGINT', exitHandler.bind(null, { exit: true }));
+	// catch uncaught exceptions
+	process.on('uncaughtException', exitHandler.bind(null, { exit: true }));
+
+	return function ()
+	{
+		return new Promise<void>((resolve, reject) =>
+		{
+			promiseList.push({ resolve, reject });
+		});
+	};
+})();


### PR DESCRIPTION
The exit event handler is subscribed only once and therefore does log errors only once.
The new behavior automatically subscribes to the exit events regardless of whether ´getDestroyPromise()´ is ever called.